### PR TITLE
fixed strtotime in test

### DIFF
--- a/tests/Namshi/Innovate/Test/Payment/CardTest.php
+++ b/tests/Namshi/Innovate/Test/Payment/CardTest.php
@@ -23,7 +23,7 @@ class CardTest extends PHPUnit_Framework_TestCase
      */
     public function testTheDateParameterCantBeExpired()
     {
-        new Card(99999, '123', new DateTime('@'.(strtotime("-1 month"))));
+        new Card(99999, '123', new DateTime('@'.(strtotime('last day of previous month'))));
     }
 
     /**


### PR DESCRIPTION
 if you run this test on a month with 31 days and the day is the 31st,  strtotime(-1 month) will give you back a unix timestamp for the first of the month, and not the last day of the previous month.
The test is failing because is expecting an "ExpiredCard" exception and,  checking the year and the month. In this case they are the same, so it's not expired.