### PR TITLE
Add credit card tokenization request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,10 @@
         {
           "name": "cirpo",
           "email": "alessandro.cinelli@gmail.com"
+        },
+        {
+          "name": "filippo",
+          "email": "filippo.desantis@gmail.com"
         }
     ],
     "autoload": {

--- a/src/Namshi/Innovate/Http/Message/EntityEnclosingRequest.php
+++ b/src/Namshi/Innovate/Http/Message/EntityEnclosingRequest.php
@@ -28,7 +28,7 @@ class EntityEnclosingRequest extends BaseRequest
     public function __construct($method, $url, $headers = array())
     {
         parent::__construct($method, $url, $headers);
-        
+
         $this->xmlBody = array();
     }
 
@@ -56,7 +56,7 @@ class EntityEnclosingRequest extends BaseRequest
         if (!empty($mpiData)) {
             $this->addMpiData($mpiData);
         }
-        
+
         $encoder    = new XmlEncoder('remote');
         $serializer = new Serializer(array(new GetSetMethodNormalizer()), array($encoder));
         $this->setBody($serializer->serialize($this->xmlBody, 'xml'));
@@ -77,8 +77,8 @@ class EntityEnclosingRequest extends BaseRequest
         $this->addKey($key);
         $this->addTransaction($transaction);
         $this->addCard($card);
-        $encoder        = new XmlEncoder('remote');
-        $serializer     = new Serializer(array(new GetSetMethodNormalizer()), array($encoder));
+        $encoder    = new XmlEncoder('remote');
+        $serializer = new Serializer(array(new GetSetMethodNormalizer()), array($encoder));
         $this->setBody($serializer->serialize($this->xmlBody, 'xml'));
     }
 

--- a/src/Namshi/Innovate/Request/Factory.php
+++ b/src/Namshi/Innovate/Request/Factory.php
@@ -3,6 +3,13 @@
 namespace Namshi\Innovate\Request;
 
 use Guzzle\Http\Message\RequestFactory;
+use Namshi\Innovate\Tokenized\Card;
+use Namshi\Innovate\Tokenized\BillingInformation;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Guzzle\Http\Client as HttpClient;
+use Namshi\Innovate\Client;
 
 /**
  * Request factory that overrides the base Guzzle factory in order to specify
@@ -12,4 +19,36 @@ class Factory extends RequestFactory
 {
     protected $entityEnclosingRequestClass = 'Namshi\\Innovate\\Http\\Message\\EntityEnclosingRequest';
     protected static $instance;
+
+    public function createTokenizeRequest(HttpClient $client, $storeId, $key, Card $card, BillingInformation $billing)
+    {
+        $body = $this->buildTokenizeRequestBody($storeId, $key, $card, $billing);
+
+        return $client->post(sprintf(Client::INNOVATE_GENERATE_CARD_TOKEN_URI), array(), $body, array(
+            'timeout'         => 5,
+            'connect_timeout' => 5
+        ));
+    }
+
+    /**
+     * Transform the card and billing info to xml format needed for a tokenize request
+     *
+     * @param  Card               $card
+     * @param  BillingInformation $billing
+     * @return string
+     */
+    protected function buildTokenizeRequestBody($storeId, $key, Card $card, BillingInformation $billing)
+    {
+        $encoder    = new XmlEncoder('remote');
+        $serializer = new Serializer(array(new GetSetMethodNormalizer()), array($encoder));
+
+        $body = [
+            'store' => $storeId,
+            'key' => $key,
+            'card' => $card->toArray(),
+            'billing' => $billing->toArray(),
+        ];
+
+        return $serializer->serialize($body, 'xml');
+    }
 }

--- a/src/Namshi/Innovate/Tokenized/BillingInformation.php
+++ b/src/Namshi/Innovate/Tokenized/BillingInformation.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Namshi\Innovate\Tokenized;
+
+use Namshi\Innovate\Payment\Billing\Customer;
+use Namshi\Innovate\Payment\Billing\Address;
+use InvalidArgumentException;
+
+/**
+ * This class represents a billing as detailed as Innovate needs it.
+ */
+class BillingInformation
+{
+    /**
+     * @var Namshi\Innovate\Payment\Billing\Customer
+     */
+    protected $customer;
+
+    /**
+     * @var Namshi\Innovate\Payment\Billing\Address
+     */
+    protected $address;
+
+    /**
+     * @var string
+     */
+    protected $email;
+
+    /**
+     * Constructor
+     *
+     * @param Billing\Customer $customer
+     * @param Billing\Address $address
+     * @param string $email
+     * @param string $ip
+     */
+    public function __construct(Customer $customer, Address $address, $email)
+    {
+        $this->setCustomer($customer);
+        $this->setAddress($address);
+        $this->setEmail($email);
+    }
+
+    /**
+     * @param Billing\Address $address
+     */
+    public function setAddress(Address $address)
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * @return Namshi\Innovate\Payment\Billing\Address
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param Billing\Customer $customer
+     */
+    public function setCustomer(Customer $customer)
+    {
+        $this->customer = $customer;
+    }
+
+    /**
+     * @return Namshi\Innovate\Payment\Billing\Customer
+     */
+    public function getCustomer()
+    {
+        return $this->customer;
+    }
+
+    /**
+     * @param $email
+     * @throws \InvalidArgumentException
+     */
+    public function setEmail($email)
+    {
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidArgumentException("The email parameter doesn't match email format.");
+        }
+
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * Converts the current object to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'name'      => $this->getCustomer()->toArray(),
+            'address'   => $this->getAddress()->toArray(),
+            'email'     => $this->getEmail()
+        );
+    }
+}

--- a/src/Namshi/Innovate/Tokenized/Card.php
+++ b/src/Namshi/Innovate/Tokenized/Card.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Namshi\Innovate\Tokenized;
+
+use InvalidArgumentException;
+use DateTime;
+use Namshi\Innovate\Exception\ExpiredCard as ExpiredCardException;
+
+/**
+ * This class represents a card as detailed as Innovate needs it.
+ */
+class Card
+{
+    /**
+     * @var string
+     */
+    protected $number;
+
+    /**
+     * @var string
+     */
+    protected $expiryMonth;
+
+    /**
+     * @var string
+     */
+    protected $expiryYear;
+
+    /** Constructor
+     *
+     * @param string $number
+     * @param string $cvv
+     * @param \DateTime $expiryData
+     */
+    public function __construct($number, DateTime $expiryData)
+    {
+        $this->setNumber($number);
+        $this->setExpiryDate($expiryData);
+    }
+
+    /**
+     * Sets expiry year and month
+     *
+     * @param \DateTime $expiryDate
+     * @throws \InvalidArgumentException
+     */
+    public function setExpiryDate(DateTime $expiryDate)
+    {
+        $currentDate  = new DateTime();
+        $currentYear  = $currentDate->format('Y');
+        $currentMonth = $currentDate->format('m');
+        $expiryYear   = $expiryDate->format('Y');
+        $expiryMonth  = $expiryDate->format('m');
+
+        if ($currentYear > $expiryYear || ($currentYear == $expiryYear && $currentMonth > $expiryMonth)) {
+            throw new ExpiredCardException("The date parameter is expired.");
+        }
+
+        $this->setExpiryMonth($expiryMonth);
+        $this->setExpiryYear($expiryYear);
+    }
+
+    /**
+     * @param $number
+     * @throws \InvalidArgumentException
+     */
+    public function setNumber($number)
+    {
+        if (!is_numeric($number)) {
+            throw new InvalidArgumentException("The number parameter must be numeric.");
+        }
+        $this->number = $number;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    /**
+     * @param $expiryMonth
+     * @throws \InvalidArgumentException
+     */
+    public function setExpiryMonth($expiryMonth)
+    {
+
+        if (!is_numeric($expiryMonth) || $expiryMonth < 1 || $expiryMonth > 12) {
+            throw new InvalidArgumentException("The expiry month parameter must be a number between 1 - 12.");
+        }
+        $this->expiryMonth = $expiryMonth;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpiryMonth()
+    {
+        return $this->expiryMonth;
+    }
+
+    /**
+     * @param $expiryYear
+     * @throws \InvalidArgumentException
+     */
+    public function setExpiryYear($expiryYear)
+    {
+        if (!is_numeric($expiryYear)) {
+            throw new InvalidArgumentException("The number parameter must be numeric.");
+        }
+        $this->expiryYear = $expiryYear;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpiryYear()
+    {
+        return $this->expiryYear;
+    }
+
+    /**
+     * Converts the current object to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'number'    => $this->getNumber(),
+            'expiry'    => array(
+                'month' => $this->getExpiryMonth(),
+                'year'  => $this->getExpiryYear(),
+            )
+        );
+    }
+}

--- a/tests/Namshi/Innovate/Test/ClientStub.php
+++ b/tests/Namshi/Innovate/Test/ClientStub.php
@@ -20,6 +20,15 @@ class ClientStub extends Client
   }
 
   /**
+  * Instead of sending the request to Innovate and returning the response, we
+  * just return the Request itself
+  */
+  public function send($request)
+  {
+    return $request;
+  }
+
+  /**
   * Instead of sending a requesto to Innovate we directly return a valid response
   * @return Response
   */

--- a/tests/Namshi/Innovate/Test/FactoryTest.php
+++ b/tests/Namshi/Innovate/Test/FactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Namshi\Innovate\Test;
+
+use Namshi\Innovate\Request\Factory;
+use Namshi\Innovate\Test\ClientStub;
+use Namshi\Innovate\Tokenized\Card;
+use Namshi\Innovate\Tokenized\BillingInformation;
+use Namshi\Innovate\Payment\Billing\Customer;
+use Namshi\Innovate\Payment\Billing\Address;
+
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTokenize()
+    {
+        $factory = new Factory();
+        $client = new ClientStub('EXAMPLE_STORE', 'EXAMPLE_MERCHANT_ID', 'xyz', 'searchkey');
+        $request = $factory->createTokenizeRequest(
+            $client,
+            $client->getStoreId(),
+            $client->getKey(),
+            new Card('4000000000000002', new \DateTime('2025-5')),
+            new BillingInformation(
+                new Customer('Forenames', 'Surname', 'Mr'),
+                new Address('STREET_ADDRESS_LINE_1', 'STREET_ADDRESS_LINE_2', 'STREET_ADDRESS_LINE_3', 'CITY', 'REGION', 'COUNTRY', '12345'),
+                'test@namshi.com'
+            )
+        );
+
+        $xml = new \SimpleXMLElement($request->getBody());
+        $this->assertEquals('EXAMPLE_STORE', (string) $xml->store);
+        $this->assertEquals('xyz', (string) $xml->key);
+        $this->assertEquals('4000000000000002',(string) $xml->card->number);
+        $this->assertEquals('05',(string) $xml->card->expiry->month);
+        $this->assertEquals('2025',(string) $xml->card->expiry->year);
+        $this->assertEquals('Forenames',(string) $xml->billing->name->first);
+        $this->assertEquals('Surname',(string) $xml->billing->name->last);
+        $this->assertEquals('STREET_ADDRESS_LINE_1',(string) $xml->billing->address->line1);
+        $this->assertEquals('STREET_ADDRESS_LINE_2',(string) $xml->billing->address->line2);
+        $this->assertEquals('STREET_ADDRESS_LINE_3',(string) $xml->billing->address->line3);
+        $this->assertEquals('CITY',(string) $xml->billing->address->city);
+        $this->assertEquals('REGION',(string) $xml->billing->address->region);
+        $this->assertEquals('COUNTRY',(string) $xml->billing->address->country);
+        $this->assertEquals('12345',(string) $xml->billing->address->zip);
+        $this->assertEquals('test@namshi.com',(string) $xml->billing->email);
+    }
+}


### PR DESCRIPTION
This PR add the ability to request an Innovate credit card token.

From the code point of view, the biggest thing this PR does is: add logic to [`Request/Factory.php`](https://github.com/namshi/innovate/compare/add-credit-card-tokenization-request?expand=1#diff-22012320254563c391cb4e2acf468c35R23) instead of adding it to the [`Namshi/Innovate/Http/Message/EntityEnclosingRequest.php`](https://github.com/namshi/innovate/compare/add-credit-card-tokenization-request?expand=1#diff-38f877aa7afe919bb17616d682c83c82L28).

This with the idea of moving all the logic from the request to the factory at some point :)

@odino @cirpo Can you give me feedback on this?